### PR TITLE
cmdext: Add `cwd_dir()` API

### DIFF
--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -1,7 +1,9 @@
 //! Extensions for [`std::process::Command`].
 
-use rustix::fd::{FromRawFd, IntoRawFd};
+use cap_std::fs::Dir;
+use rustix::fd::{AsFd, FromRawFd, IntoRawFd};
 use rustix::io::OwnedFd;
+use std::ops::Deref;
 use std::os::unix::process::CommandExt;
 use std::sync::Arc;
 
@@ -9,6 +11,11 @@ use std::sync::Arc;
 pub trait CapStdExtCommandExt {
     /// Pass a file descriptor into the target process.
     fn take_fd_n(&mut self, fd: Arc<OwnedFd>, target: i32) -> &mut Self;
+
+    /// Use the given directory as the current working directory for the process.
+    fn cwd_dir<T>(&mut self, dir: Arc<T>) -> &mut Self
+    where
+        T: Deref<Target = Dir> + Send + Sync + 'static;
 }
 
 #[allow(unsafe_code)]
@@ -20,6 +27,19 @@ impl CapStdExtCommandExt for std::process::Command {
                 rustix::io::dup2(&*fd, &target)?;
                 // Intentionally leak into the child.
                 let _ = target.into_raw_fd();
+                Ok(())
+            });
+        }
+        self
+    }
+
+    fn cwd_dir<T>(&mut self, dir: Arc<T>) -> &mut Self
+    where
+        T: Deref<Target = Dir> + Send + Sync + 'static,
+    {
+        unsafe {
+            self.pre_exec(move || {
+                rustix::process::fchdir(dir.as_fd())?;
                 Ok(())
             });
         }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -27,6 +27,22 @@ fn take_fd() -> Result<()> {
 }
 
 #[test]
+fn fchdir() -> Result<()> {
+    let td = Arc::new(cap_tempfile::tempdir(cap_std::ambient_authority())?);
+    let contents = b"hello world";
+    td.write("somefile", contents)?;
+    let mut c = Command::new("/usr/bin/cat");
+    c.arg("somefile");
+    c.cwd_dir(Arc::clone(&td));
+    let st = c.output()?;
+    if !st.status.success() {
+        anyhow::bail!("Failed to exec cat");
+    }
+    assert_eq!(st.stdout.as_slice(), contents);
+    Ok(())
+}
+
+#[test]
 fn optionals() -> Result<()> {
     let td = cap_tempfile::tempdir(cap_std::ambient_authority())?;
 


### PR DESCRIPTION
This is a very natural extension to capability APIs.  In rpm-ostree
we want to invoke `cpio` in a specified directory.

I originally had this just take an `Arc<Dir>` but needed to add
dynamic dispatch so we can use a tempdir.