### PR TITLE
tempfile: Add support for no-`O_TMPFILE`

### DIFF
--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -6,7 +6,7 @@
 
 use cap_std::fs::{Dir, File, Permissions};
 use rustix::fd::{AsFd, FromFd};
-use rustix::fs::{AtFlags, Mode, OFlags};
+use rustix::fs::{AtFlags, Mode, OFlags, OpenOptionsExt};
 use rustix::path::DecInt;
 use std::ffi::OsStr;
 use std::io::{Result, Write};
@@ -32,6 +32,72 @@ fn new_name() -> String {
     }
 }
 
+/// Create a new temporary file in the target directory, which may or may not have a (randomly generated) name at this point.
+fn new_tempfile(d: &Dir) -> Result<(File, Option<rustix::ffi::ZString>)> {
+    // openat's API uses WRONLY.  There may be use cases for reading too, so let's support it.
+    let oflags = OFlags::CLOEXEC | OFlags::TMPFILE | OFlags::RDWR;
+    let mode = Mode::RUSR | Mode::WUSR;
+    // Happy path - Linux with O_TMPFILE
+    match rustix::fs::openat(d, ".", oflags, mode) {
+        Ok(r) => return Ok(((File::from_fd(r.into())), None)),
+        Err(e) if e == rustix::io::Error::OPNOTSUPP => {}
+        Err(e) => {
+            return Err(e.into());
+        }
+    };
+    // Otherwise, fall back
+    let mut attempts = 0u32;
+    let mut opts = cap_std::fs::OpenOptions::new();
+    opts.read(true);
+    opts.write(true);
+    opts.create_new(true);
+    opts.mode(mode.as_raw_mode());
+    loop {
+        attempts = attempts.saturating_add(1);
+        if attempts == u32::MAX {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "too many temporary files exist",
+            ));
+        }
+        let name = new_name();
+        match d.open_with(&name, &opts) {
+            Ok(r) => return Ok((r, Some(rustix::ffi::ZString::new(name)?))),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Assign a random name to a currently anonymous O_TMPFILE descriptor.
+fn generate_name_in(subdir: &Dir, f: &File) -> Result<rustix::ffi::ZString> {
+    let procself_fd = rustix::io::proc_self_fd()?;
+    let fdnum = rustix::path::DecInt::from_fd(&f.as_fd());
+    let mut attempts = 0u32;
+    let tempname = loop {
+        attempts = attempts.saturating_add(1);
+        if attempts == u32::MAX {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "too many temporary files exist",
+            ));
+        }
+        let name = new_name();
+        match rustix::fs::linkat(
+            &procself_fd,
+            fdnum.as_c_str(),
+            subdir,
+            &name,
+            AtFlags::SYMLINK_FOLLOW,
+        ) {
+            Ok(()) => break name,
+            Err(e) if e == rustix::io::Error::EXIST => continue,
+            Err(e) => return Err(e.into()),
+        }
+    };
+    Ok(rustix::ffi::ZString::new(tempname)?)
+}
+
 /// A temporary file that may be given a persistent name.
 #[derive(Debug)]
 pub struct LinkableTempfile<'p, 'd> {
@@ -39,6 +105,7 @@ pub struct LinkableTempfile<'p, 'd> {
     dir: &'d Dir,
     subdir: Option<Dir>,
     fd: File,
+    tempname: Option<rustix::ffi::ZString>,
 }
 
 impl<'p, 'd> Deref for LinkableTempfile<'p, 'd> {
@@ -75,17 +142,13 @@ impl<'p, 'd> LinkableTempfile<'p, 'd> {
         } else {
             None
         };
-        let subdir_fd = subdir.as_ref().unwrap_or(dir).as_fd();
-        // openat's API uses WRONLY.  There may be use cases for reading too, so let's support it.
-        let oflags = OFlags::CLOEXEC | OFlags::TMPFILE | OFlags::RDWR;
-        let mode = Mode::RUSR | Mode::WUSR;
-        let fd = rustix::fs::openat(&subdir_fd, ".", oflags, mode)?;
-        let fd = File::from_fd(fd.into());
+        let (fd, tempname) = new_tempfile(subdir.as_ref().unwrap_or(dir))?;
         Ok(Self {
             name,
             dir,
             subdir,
             fd,
+            tempname,
         })
     }
 
@@ -105,46 +168,23 @@ impl<'p, 'd> LinkableTempfile<'p, 'd> {
     }
 
     /// Write the file to its destination with the chosen permissions.
-    pub fn replace_with_perms(self, permissions: Permissions) -> Result<()> {
-        let subdir = self.subdir();
-        let fd = self.fd.as_fd();
-        let procself_fd = rustix::io::proc_self_fd()?;
-        let fdnum = rustix::path::DecInt::from_fd(&fd);
-        let mut attempts = 0u32;
-        let tempname = loop {
-            attempts = attempts.saturating_add(1);
-            if attempts == u32::MAX {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "too many temporary files exist",
-                ));
-            }
-            let name = new_name();
-            match rustix::fs::linkat(
-                &procself_fd,
-                fdnum.as_c_str(),
-                subdir,
-                &name,
-                AtFlags::SYMLINK_FOLLOW,
-            ) {
-                Ok(()) => break name,
-                Err(e) if e == rustix::io::Error::EXIST => continue,
-                Err(e) => return Err(e.into()),
-            }
-        };
+    pub fn replace_with_perms(mut self, permissions: Permissions) -> Result<()> {
+        let subdir = self.subdir.take();
+        let subdir = subdir.as_ref().unwrap_or(self.dir);
         self.fd.set_permissions(permissions)?;
-        // We could avoid the error here if we infallibly constructed the uuid as CString.
-        let tempname = rustix::ffi::ZString::new(tempname)?;
-        // TODO: panic-safe cleanup of the tempfile.  But I think the only case where we could panic is OOM
-        match rustix::fs::renameat(subdir, &tempname, subdir, self.name) {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                // Clean up our temporary file, but ignore errors doing so because
-                // the real error was probably from the rename(), and we don't want to mask it.
-                let _ = rustix::fs::unlinkat(subdir, tempname, AtFlags::empty());
-                Err(e.into())
-            }
-        }
+        // Take ownership of the temporary name now
+        let tempname = if let Some(t) = self.tempname.take() {
+            t
+        } else {
+            generate_name_in(subdir, &self.fd)?
+        };
+        // And try the rename.
+        rustix::fs::renameat(subdir, &tempname, subdir, self.name).map_err(|e| {
+            // But, if we catch an error here, then move ownership back into self,
+            // whioch means the Drop invocation will clean it up.
+            self.tempname = Some(tempname);
+            e.into()
+        })
     }
 
     /// Write the given contents to the file to its destination with the chosen permissions.
@@ -185,7 +225,15 @@ impl<'p, 'd> LinkableTempfile<'p, 'd> {
 
     /// Write the file to its destination, erroring out if there is an extant file.
     pub fn emplace(self) -> Result<()> {
-        let fdnum = rustix::path::DecInt::from_fd(&self.fd);
+        let fdnum = rustix::path::DecInt::from_fd(&self.fd.as_fd());
         Self::try_emplace_to(self.subdir(), &fdnum, self.name).map_err(|e| e.into())
+    }
+}
+
+impl<'p, 'd> Drop for LinkableTempfile<'p, 'd> {
+    fn drop(&mut self) {
+        if let Some(name) = self.tempname.take() {
+            let _ = rustix::fs::unlinkat(self.subdir(), name, AtFlags::empty());
+        }
     }
 }


### PR DESCRIPTION
Sadly RHEL8's `overlayfs` doesn't support it, and we end up using
that in many places obviously.

The more I think about this the more I think we should try to
land this code in `cap-tempfile`.