### PR TITLE
Add `symlink_metadata_optional()`

### DIFF
--- a/src/dirext.rs
+++ b/src/dirext.rs
@@ -28,6 +28,9 @@ pub trait CapStdExtDirExt {
     /// Gather metadata, but return `Ok(None)` if it does not exist.
     fn metadata_optional(&self, path: impl AsRef<Path>) -> Result<Option<Metadata>>;
 
+    /// Gather metadata (but do not follow symlinks), but return `Ok(None)` if it does not exist.
+    fn symlink_metadata_optional(&self, path: impl AsRef<Path>) -> Result<Option<Metadata>>;
+
     /// Remove (delete) a file, but return `Ok(false)` if the file does not exist.
     fn remove_file_optional(&self, path: impl AsRef<Path>) -> Result<bool>;
 
@@ -122,6 +125,10 @@ impl CapStdExtDirExt for Dir {
 
     fn metadata_optional(&self, path: impl AsRef<Path>) -> Result<Option<Metadata>> {
         map_optional(self.metadata(path.as_ref()))
+    }
+
+    fn symlink_metadata_optional(&self, path: impl AsRef<Path>) -> Result<Option<Metadata>> {
+        map_optional(self.symlink_metadata(path.as_ref()))
     }
 
     fn remove_file_optional(&self, path: impl AsRef<Path>) -> Result<bool> {


### PR DESCRIPTION
A trap I've been hitting when porting our helpers from `openat`
to `cap-std` is around symlink following.

It actually makes sense that our `metadata_optional()` wrapper
does follow symlinks, just like `metadata()`.  But, there are a ton
of paths where we don't want to follow symlinks, so add that
wrapper too.