### PR TITLE
Bump to cap-std 0.25 and rustix 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@ license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/cgwalters/cap-std-ext"
-version = "0.25.0"
+# Confusingly our version is one greater than cap-std for historical reasons.
+version = "0.26.0"
 
 [dependencies]
-cap-std = "0.24"
-cap-tempfile = "0.24.3"
+cap-std = "0.25"
+cap-tempfile = "0.25"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.33.0", features = ["procfs"] }
+rustix = { version = "0.35.0", features = ["procfs"] }
 #rustix = { git = "https://github.com/bytecodealliance/rustix", features = ["procfs"] }
 
 [dev-dependencies]

--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -29,8 +29,8 @@ impl CapStdExtCommandExt for std::process::Command {
     fn take_fd_n(&mut self, fd: Arc<OwnedFd>, target: i32) -> &mut Self {
         unsafe {
             self.pre_exec(move || {
-                let target = rustix::io::OwnedFd::from_raw_fd(target);
-                rustix::io::dup2(&*fd, &target)?;
+                let mut target = rustix::io::OwnedFd::from_raw_fd(target);
+                rustix::io::dup2(&*fd, &mut target)?;
                 // Intentionally leak into the child.
                 let _ = target.into_raw_fd();
                 Ok(())

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -179,7 +179,7 @@ fn link_tempfile_with() -> Result<()> {
         td.read_to_string(p).unwrap().as_str(),
         "atomic replacement 3\n"
     );
-    assert_eq!(td.metadata(p)?.permissions().mode(), 0o700);
+    assert_eq!(td.metadata(p)?.permissions().mode() & 0o777, 0o700);
 
     Ok(())
 }


### PR DESCRIPTION
On general principle, but specifically this will help get
rpm-ostree out of having two rustix versions
because `memfd` pulls in rustix 0.35 already.