### PR TITLE
Update to Rust 2021

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.54.0
+  ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.56.0
+  ACTION_LINTS_TOOLCHAIN: 1.58.1
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Colin Walters <walters@verbum.org>"]
 description = "Extension APIs for cap-std"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"


### PR DESCRIPTION
ci: Bump MSRV

This matches other CoreOS projects, and lets us use Edition 2021.

---

Update to Rust 2021

No major changes.

```
$ cargo fix --edition
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  getrandom v0.2.7 removed features: std
  libc v0.2.126 removed features: default, extra_traits, std
```

---

