### PR TITLE
cmdext: Remove not-very-usable `cwd_dir_owned`

### DIFF
--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -16,12 +16,6 @@ pub trait CapStdExtCommandExt {
     fn cwd_dir<T>(&mut self, dir: Arc<T>) -> &mut Self
     where
         T: Deref<Target = Dir> + Send + Sync + 'static;
-
-    /// Use the given directory as the current working directory for the process.
-    /// This command replaces [`cwd_dir`] which due to a mistake in API design
-    /// effectively only supports [`cap_tempfile::TempDir`] and not plain [`cap_std::fs::Dir`]
-    /// instances.
-    fn cwd_dir_owned(&mut self, dir: Dir) -> &mut Self;
 }
 
 #[allow(unsafe_code)]
@@ -43,16 +37,6 @@ impl CapStdExtCommandExt for std::process::Command {
     where
         T: Deref<Target = Dir> + Send + Sync + 'static,
     {
-        unsafe {
-            self.pre_exec(move || {
-                rustix::process::fchdir(dir.as_fd())?;
-                Ok(())
-            });
-        }
-        self
-    }
-
-    fn cwd_dir_owned(&mut self, dir: Dir) -> &mut Self {
         unsafe {
             self.pre_exec(move || {
                 rustix::process::fchdir(dir.as_fd())?;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -54,11 +54,6 @@ fn fchdir() -> Result<()> {
     c.cwd_dir(Arc::clone(&td));
     test_cmd(c).unwrap();
 
-    let mut c = new_cmd();
-    let subdir = td.open_dir(".")?;
-    c.cwd_dir_owned(subdir.try_clone()?);
-    test_cmd(c).unwrap();
-
     Ok(())
 }
 


### PR DESCRIPTION
As the docstring says it only really works on `TempDir` which
isn't very useful.  I only kept it for compat at the time, but
we bumped semver recently.