### PR TITLE
Use re-exported `cap_tempfile::cap_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ repository = "https://github.com/cgwalters/cap-std-ext"
 version = "0.26.0"
 
 [dependencies]
-cap-std = "0.25"
-cap-tempfile = "0.25"
+cap-tempfile = "0.25.1"
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.0", features = ["procfs"] }

--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -1,6 +1,7 @@
 //! Extensions for [`std::process::Command`].
 
 use cap_std::fs::Dir;
+use cap_tempfile::cap_std;
 use rustix::fd::{AsFd, FromRawFd, IntoRawFd};
 use rustix::io::OwnedFd;
 use std::ops::Deref;

--- a/src/dirext.rs
+++ b/src/dirext.rs
@@ -3,6 +3,7 @@
 //! [`cap_std::fs::Dir`]: https://docs.rs/cap-std/latest/cap_std/fs/struct.Dir.html
 
 use cap_std::fs::{Dir, File, Metadata};
+use cap_tempfile::cap_std;
 use std::ffi::OsStr;
 use std::io::Result;
 use std::io::{self, Write};
@@ -46,6 +47,7 @@ pub trait CapStdExtDirExt {
     /// ```rust
     /// # use std::io;
     /// # use std::io::Write;
+    /// # use cap_tempfile::cap_std;
     /// # fn main() -> io::Result<()> {
     /// # let somedir = cap_tempfile::tempdir(cap_std::ambient_authority())?;
     /// use cap_std_ext::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 // Re-export our dependencies
-pub use cap_std;
+pub use cap_tempfile::cap_std;
 #[cfg(not(windows))]
 pub use rustix;
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+
 use cap_std::fs::{Dir, Permissions};
+use cap_std_ext::cap_std;
 use cap_std_ext::cmdext::CapStdExtCommandExt;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use rustix::fd::FromFd;


### PR DESCRIPTION
This means we only have to have one crate dependency, not two.
The cost is more import juggling, but that's OK.