### PR TITLE
Release 0.26.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"
-repository = "https://github.com/cgwalters/cap-std-ext"
+repository = "https://github.com/coreos/cap-std-ext"
 # Confusingly our version is one greater than cap-std for historical reasons.
 version = "0.26.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
 # Confusingly our version is one greater than cap-std for historical reasons.
-version = "0.26.1"
+version = "0.26.2"
 
 [dependencies]
 cap-tempfile = "0.25.1"


### PR DESCRIPTION
Cargo.toml: Fix repository link

---

Release 0.26.2

To get out the new API.

---

