### PR TITLE
dirext: Add an `update_timestamps()` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.26.2"
 cap-tempfile = "0.25.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.0", features = ["procfs"] }
+rustix = { version = "0.35.0", features = ["fs", "procfs"] }
 #rustix = { git = "https://github.com/bytecodealliance/rustix", features = ["procfs"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This mirrors https://github.com/coreos/openat-ext/pull/36/commits/1df874d328d507d6bb2b41a1fcfecf002602677d

And for the same reason - we're going to use it in the rpm-ostree port
to cap-std.