### PR TITLE
Bump to 1.0, matching cap-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,19 @@
 authors = ["Colin Walters <walters@verbum.org>"]
 description = "Extension APIs for cap-std"
 edition = "2021"
+rust-version = "1.58.0"
 license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
-# Confusingly our version is one greater than cap-std for historical reasons.
-version = "0.26.2"
+version = "1.0.0"
 
 [dependencies]
-cap-tempfile = "0.25.1"
+cap-tempfile = "1.0.1"
+io-lifetimes = "1.0.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.0", features = ["fs", "procfs"] }
+rustix = { version = "0.36.0", features = ["fs", "procfs"] }
 #rustix = { git = "https://github.com/bytecodealliance/rustix", features = ["procfs"] }
 
 [dev-dependencies]

--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -2,8 +2,8 @@
 
 use cap_std::fs::Dir;
 use cap_tempfile::cap_std;
+use io_lifetimes::OwnedFd;
 use rustix::fd::{AsFd, FromRawFd, IntoRawFd};
-use rustix::io::OwnedFd;
 use std::os::unix::process::CommandExt;
 use std::sync::Arc;
 
@@ -21,7 +21,7 @@ impl CapStdExtCommandExt for std::process::Command {
     fn take_fd_n(&mut self, fd: Arc<OwnedFd>, target: i32) -> &mut Self {
         unsafe {
             self.pre_exec(move || {
-                let mut target = rustix::io::OwnedFd::from_raw_fd(target);
+                let mut target = OwnedFd::from_raw_fd(target);
                 rustix::io::dup2(&*fd, &mut target)?;
                 // Intentionally leak into the child.
                 let _ = target.into_raw_fd();

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 
-use cap_std::fs::{Dir, Permissions};
+use cap_std::fs::{Dir, File, Permissions};
 use cap_std_ext::cap_std;
 use cap_std_ext::cmdext::CapStdExtCommandExt;
 use cap_std_ext::dirext::CapStdExtDirExt;
-use rustix::fd::FromFd;
 use std::io::Write;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
@@ -17,7 +16,7 @@ fn take_fd() -> Result<()> {
     c.arg("wc -c <&5");
     let (r, w) = rustix::io::pipe()?;
     let r = Arc::new(r);
-    let mut w = cap_std::fs::File::from_fd(w.into());
+    let mut w: File = w.into();
     c.take_fd_n(r.clone(), 5);
     write!(w, "hello world")?;
     drop(w);


### PR DESCRIPTION
This will end one major source of semver bumps for our reverse dependencies.

For our API...it's not perfect, but it's working well enough and I think we can commit to it.