### PR TITLE
lib: Also re-export cap-tempfile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 // Re-export our dependencies
+pub use cap_tempfile;
 pub use cap_tempfile::cap_std;
 #[cfg(not(windows))]
 pub use rustix;


### PR DESCRIPTION
For the same reason we re-export cap-std; this way our consumers only have one thing they need in `Cargo.toml` that can be bumped atomically.