### PR TITLE
Use re-exported `io_lifetimes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "1.0.0"
 
 [dependencies]
 cap-tempfile = "1.0.1"
-io-lifetimes = "1.0.1"
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.36.0", features = ["fs", "procfs"] }

--- a/src/cmdext.rs
+++ b/src/cmdext.rs
@@ -1,6 +1,7 @@
 //! Extensions for [`std::process::Command`].
 
 use cap_std::fs::Dir;
+use cap_std::io_lifetimes;
 use cap_tempfile::cap_std;
 use io_lifetimes::OwnedFd;
 use rustix::fd::{AsFd, FromRawFd, IntoRawFd};


### PR DESCRIPTION
Just on general principle, no reason to add our own requirements here.