### PR TITLE
ci: Revamp

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,49 +14,54 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.58.1
 
 jobs:
   build:
+    name: "Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
-      - name: Build
-        run: cargo test --no-run && cargo build
-      - name: Run tests
-        run: cargo test -- --nocapture --quiet
+        uses: Swatinem/rust-cache@v2
+      - name: Compile (no features)
+        run: cargo test --no-run
+      - name: Compile (all features)
+        run: cargo test --no-run --all-features
+      - name: Test
+        run: cargo test --all-features -- --nocapture --quiet
   build-minimum-toolchain:
     name: "Build, minimum supported toolchain (MSRV)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions/checkout@v3
+      - name: Detect crate MSRV
+        shell: bash
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[0].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "ACTION_MSRV_TOOLCHAIN=$msrv" >> $GITHUB_ENV
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
-          default: true
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+        uses: Swatinem/rust-cache@v2
       - name: cargo check
         run: cargo check
   linting:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          default: true
           components: rustfmt, clippy
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l


### PR DESCRIPTION
This updates to match https://github.com/containers/containers-image-proxy-rs/pull/40

- Use `checkout@v3` to avoid deprecation warnings
- switch to https://github.com/dtolnay/rust-toolchain after seeing https://www.reddit.com/r/rust/comments/z1mlls/actionsrs_github_actions_need_more_maintainers_or/

We also now also for now don't use the fcos buildroot, because we don't need to.