### PR TITLE
build: Add `process` feature for rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "1.0.2"
 cap-tempfile = "1.0.1"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.36.0", features = ["fs", "procfs"] }
+rustix = { version = "0.36.0", features = ["fs", "procfs", "process"] }
 #rustix = { git = "https://github.com/bytecodealliance/rustix", features = ["procfs"] }
 
 [dev-dependencies]


### PR DESCRIPTION
It looks like a backported change in the 0.36 series started requiring this.