### PR TITLE
Drop rustix export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
-version = "1.0.3"
+version = "2.0.0"
 
 [dependencies]
 cap-tempfile = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 // Re-export our dependencies
 pub use cap_tempfile;
 pub use cap_tempfile::cap_std;
-#[cfg(not(windows))]
-pub use rustix;
 
 #[cfg(not(windows))]
 pub mod cmdext;


### PR DESCRIPTION
lib: Bump to semver 2.0

Prep for breaking changes.

---

lib: Drop re-export of rustix

In hindsight this was a bad idea because we need to bump
our semver whenever rustix does.

---

