### PR TITLE
lib: Re-export cap-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "3.0.0"
 
 [dependencies]
 cap-tempfile = "2"
+cap-primitives = "2"
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.38", features = ["fs", "procfs", "process", "pipe"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Extension APIs for cap-std
 This crate adds additional helper APIs on top of the [`cap-std crate`].
 
+[![crates.io](https://img.shields.io/crates/v/cap-std-ext.svg)](https://crates.io/crates/cap-std-ext)
+
+[Documentation (Releases)](https://docs.rs/cap-std-ext/)
+
 This crate will aim to migrate extension APIs from
 [openat-ext](https://docs.rs/openat-ext/latest/openat_ext/index.html).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 // Re-export our dependencies
+pub use cap_primitives;
 pub use cap_tempfile;
 pub use cap_tempfile::cap_std;
 


### PR DESCRIPTION
lib: Re-export cap-primitives

For the same reason we re-export `cap-std`; in practice it needs
to be version locked.

(I know the idea of `cap-primitives` is that it's an implementation
 detail, but in practice cap-std also re-exports at least `ipnet`
 from it, so...it kind of has to be equally stable)

---

README.md: Add crates.io and docs.rs links

They're handy.

---

