### PR TITLE
Use cap-std 2.x, rustix 0.38 - bump to 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,14 @@ license = "MIT OR Apache-2.0"
 name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
-version = "2.0.0"
+# For historical reasons, the major version number is one greater than the cap-std major.
+version = "3.0.0"
 
 [dependencies]
-cap-tempfile = "1.0.1"
+cap-tempfile = "2"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = ">= 0.36, <= 0.38", features = ["fs", "procfs", "process"] }
+rustix = { version = "0.38", features = ["fs", "procfs", "process", "pipe"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -14,7 +14,7 @@ fn take_fd() -> Result<()> {
     let mut c = Command::new("/bin/bash");
     c.arg("-c");
     c.arg("wc -c <&5");
-    let (r, w) = rustix::io::pipe()?;
+    let (r, w) = rustix::pipe::pipe()?;
     let r = Arc::new(r);
     let mut w: File = w.into();
     c.take_fd_n(r, 5);


### PR DESCRIPTION
Basically since cap-std bumped semver, we need to do so as well. xref https://github.com/bytecodealliance/cap-std/commit/963eebf3ab52b04a2e8b9ba88ce6308bbed5cbd0#r121651362

Also it's now a bit harder to compile against multiple rustix versions, so stop trying and use 0.38 for now.

Closes: https://github.com/coreos/cap-std-ext/issues/42