### PR TITLE
Release 3.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
 # For historical reasons, the major version number is one greater than the cap-std major.
-version = "3.0.0"
+version = "3.0.1"
 
 [dependencies]
 cap-tempfile = "2"


### PR DESCRIPTION
This just has the cap-primitives reexport.