### PR TITLE
Add a fs_utf8 feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,9 @@ jobs:
         run: cargo build --all-targets
       - name: cargo test
         run: cargo test --all-targets
+      - name: cargo test (fs_utf8)
+        run: cargo test --features=fs_utf8
+
   tests-release-stable:
     name: Tests (release), stable toolchain
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/coreos/cap-std-ext"
 version = "4.0.0"
 
 [dependencies]
-cap-tempfile = "3"
+cap-tempfile = "3.2.0"
 cap-primitives = "3"
 
 [target.'cfg(not(windows))'.dependencies]
@@ -19,3 +19,10 @@ rustix = { version = "0.38", features = ["fs", "procfs", "process", "pipe"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+
+[features]
+default = []
+# This just enables support for the fs_utf8 feature in cap-std.
+fs_utf8 = [
+    "cap-tempfile/fs_utf8",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 
 // Re-export our dependencies
 pub use cap_primitives;
+#[cfg(feature = "fs_utf8")]
+pub use cap_std::fs_utf8::camino;
 pub use cap_tempfile;
 pub use cap_tempfile::cap_std;
 
@@ -20,4 +22,6 @@ pub mod prelude {
     #[cfg(not(windows))]
     pub use super::cmdext::CapStdExtCommandExt;
     pub use super::dirext::CapStdExtDirExt;
+    #[cfg(feature = "fs_utf8")]
+    pub use super::dirext::CapStdExtDirExtUtf8;
 }


### PR DESCRIPTION
I'd like to potentially start making use of the `fs_utf8::Dir` in a lot of code in e.g. bootc/ostree related things because ostree in particular hard requires UTF-8 filenames, and we have redundant verifications.

This makes use of the new `as_cap_std()` API that landed in cap-std.