### PR TITLE
dir+utf8: Add `filenames` and `filenames_filtered`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rustix = { version = "0.38", features = ["fs", "procfs", "process", "pipe"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+uuid = "1.10"
 
 [features]
 default = []


### PR DESCRIPTION
More convenience helpers, particularly for the use case where one wants to gather a list of filenames (possibly filtered) and sort them.

(We don't do sorting here, but it's trivial to do after calling
 `filenames_filtered()`)