### PR TITLE
dir: Add an `is_mountpoint` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cap-primitives = "3"
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.38", features = ["fs", "procfs", "process", "pipe"] }
+libc = "0.2"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -383,3 +383,12 @@ fn test_rootdir_entries() -> Result<()> {
     assert_eq!(ents.len(), 2);
     Ok(())
 }
+
+#[test]
+fn test_mountpoint() -> Result<()> {
+    let root = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+    assert_eq!(root.is_mountpoint(".").unwrap(), Some(true));
+    let td = &cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
+    assert_eq!(td.is_mountpoint(".").unwrap(), Some(false));
+    Ok(())
+}


### PR DESCRIPTION
Copy the code from https://github.com/ostreedev/ostree-rs-ext/pull/551 as it's better here.