### PR TITLE
Add a `walk` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2"
 
 [dev-dependencies]
 anyhow = "1.0"
+rand = "0.9"
 uuid = "1.10"
 
 [features]


### PR DESCRIPTION
There's a ton of use cases for a recursive directory walk, and we end up re-implementing it over and over.

Unlike the `walkdir` crate, this runs via "internal iteration" that accepts a closure which returns `std::ops::ControlFlow` to ensure the caller can break out of iteration.

There's a config option that supports:

- Not traversing mount points
- Sorting entries