### PR TITLE
dirext: Add getxattr/setxattr wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
+use std::io;
+
 // Re-export our dependencies
 pub use cap_primitives;
 #[cfg(feature = "fs_utf8")]
@@ -19,7 +21,20 @@ pub mod dirext;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 mod rootdir;
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub use rootdir::*;
+#[cfg(not(windows))]
+mod xattrs;
+#[cfg(not(windows))]
+pub use xattrs::XattrList;
+
+#[cold]
+pub(crate) fn escape_attempt() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "a path led outside of the filesystem",
+    )
+}
 
 /// Prelude, intended for glob import.
 pub mod prelude {

--- a/src/xattrs.rs
+++ b/src/xattrs.rs
@@ -1,0 +1,108 @@
+use std::io::Result;
+use std::{
+    ffi::OsStr,
+    os::unix::ffi::OsStrExt,
+    path::{Path, PathBuf},
+};
+
+use cap_tempfile::cap_std::fs::Dir;
+use rustix::buffer::spare_capacity;
+
+use crate::dirext::validate_relpath_no_uplinks;
+
+/// Convert the directory and path pair into a /proc/self/fd path
+/// which is useful for xattr functions in particular to be able
+/// to operate on symlinks.
+///
+/// Absolute paths as well as paths with uplinks (`..`) are an error.
+fn proc_self_path(d: &Dir, path: &Path) -> Result<PathBuf> {
+    use rustix::path::DecInt;
+    use std::os::fd::{AsFd, AsRawFd};
+
+    // Require relative paths here.
+    let path = validate_relpath_no_uplinks(path)?;
+
+    let mut pathbuf = PathBuf::from("/proc/self/fd");
+    pathbuf.push(DecInt::new(d.as_fd().as_raw_fd()));
+    pathbuf.push(path);
+    Ok(pathbuf)
+}
+
+pub(crate) fn impl_getxattr(d: &Dir, path: &Path, key: &OsStr) -> Result<Option<Vec<u8>>> {
+    let path = &proc_self_path(d, path)?;
+
+    // In my experience few extended attributes exceed this
+    let mut buf = Vec::with_capacity(256);
+
+    loop {
+        match rustix::fs::lgetxattr(path, key, spare_capacity(&mut buf)) {
+            Ok(_) => {
+                return Ok(Some(buf));
+            }
+            Err(rustix::io::Errno::NODATA) => {
+                return Ok(None);
+            }
+            Err(rustix::io::Errno::RANGE) => {
+                buf.reserve(buf.capacity().saturating_mul(2));
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+}
+
+/// A list of extended attribute value names
+#[derive(Debug)]
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub struct XattrList {
+    /// Contents of the return value from the llistxattr system call;
+    /// effectively Vec<OsStr> with an empty value as terminator.
+    /// Not public - we expect callers to invoke the `iter()` method.
+    /// When Rust has lending iterators then we could implement IntoIterator
+    /// in a way that borrows from this value.
+    buf: Vec<u8>,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+impl XattrList {
+    /// Return an iterator over the elements of this extended attribute list.
+    pub fn iter(&self) -> impl Iterator<Item = &'_ std::ffi::OsStr> {
+        self.buf.split(|&v| v == 0).filter_map(|v| {
+            // Note this case should only happen once at the end
+            if v.is_empty() {
+                None
+            } else {
+                Some(OsStr::from_bytes(v))
+            }
+        })
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub(crate) fn impl_listxattrs(d: &Dir, path: &Path) -> Result<XattrList> {
+    let path = &proc_self_path(d, path)?;
+
+    let mut buf = Vec::with_capacity(512);
+
+    loop {
+        match rustix::fs::llistxattr(path, spare_capacity(&mut buf)) {
+            Ok(_) => {
+                return Ok(XattrList { buf });
+            }
+            Err(rustix::io::Errno::RANGE) => {
+                buf.reserve(buf.capacity().saturating_mul(2));
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub(crate) fn impl_setxattr(d: &Dir, path: &Path, key: &OsStr, value: &[u8]) -> Result<()> {
+    let path = &proc_self_path(d, path)?;
+    rustix::fs::lsetxattr(path, key, value, rustix::fs::XattrFlags::empty())?;
+    Ok(())
+}


### PR DESCRIPTION
There's a lot of subtleties to these APIs. First,
unlike the `xattrs` crate, we operate on cap-std `Dir` objects. As part of that, we also explicitly error out on absolute paths, as well as paths containing any uplinks (`../`) at all.

- Always use `/proc/self/fd` with `lgetxattr` because this is the only way to get/set xattrs on symlinks.
- Return a `Result<Option<>>` with getxattr for consistency with our other APIs to handle the common case of looking for a nonexistent xattr.
- The `getxattr` API is also higher level than what Rustix offers to be maximally convenient; we always return an owned buffer, and handle resizing it.