### PR TITLE
lib: Drop unused feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(missing_debug_implementations)]
 #![forbid(unused_must_use)]
 #![deny(unsafe_code)]
-#![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 // Re-export our dependencies
 pub use cap_primitives;


### PR DESCRIPTION
I think this got cargo culted from elsewhere; where necessary I believe the status quo is to use `#![cfg(docsrs)]` or so.

This squashes a build warning.