### PR TITLE
Release 4.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "cap-std-ext"
 readme = "README.md"
 repository = "https://github.com/coreos/cap-std-ext"
 # For historical reasons, the major version number is one greater than the cap-std major.
-version = "4.0.6"
+version = "4.0.7"
 
 [dependencies]
 cap-tempfile = "3.2.0"


### PR DESCRIPTION
To get https://github.com/coreos/cap-std-ext/pull/69 out.